### PR TITLE
Prevent OOM in read_from_client() for large uploads

### DIFF
--- a/lib/CGI/PSGI.pm
+++ b/lib/CGI/PSGI.pm
@@ -3,6 +3,7 @@ package CGI::PSGI;
 use strict;
 use 5.008_001;
 our $VERSION = '0.15';
+our $MAX_READ_SIZE = 1024*1024;
 
 use base qw(CGI);
 
@@ -28,6 +29,8 @@ sub env {
 
 sub read_from_client {
     my($self, $buff, $len, $offset) = @_;
+    # Prevent OOM on psgi.input, which can read the whole input to memory
+    $len = $MAX_READ_SIZE if $len > $MAX_READ_SIZE;
     $self->{psgi_env}{'psgi.input'}->read($$buff, $len, $offset);
 }
 


### PR DESCRIPTION
CGI.pm calls ->read_from_client() with the whole Content-Length.
In CGI.pm (or under mod_perl) it does not matter, as the socket
filehandle always returns partial read, and thus the chunk read
into memory is not excessively large.

On the other hand, psgi.input handle can be buffered, and tries to
satisfy the whole ->read() at once. This can lead to excessive memory
usage even in situations, which CGI.pm tries to prevent (reading uploads
to temporary files instead of memory, etc.).

The fix is to impose the upper limit of bytes read in one call
to read_from_client().